### PR TITLE
Add navbar navigation menu above header

### DIFF
--- a/chess-tutor/src/App.jsx
+++ b/chess-tutor/src/App.jsx
@@ -1,5 +1,6 @@
 import ChessBoard from "./components/ChessBoard";
 import MoveHistory from "./components/MoveHistory";
+import Navbar from "./components/Navbar";
 
 import useChessStore from "./stores/useChessStore";
 
@@ -10,6 +11,7 @@ function App() {
   const resetGame = useChessStore((state) => state.resetGame);
   return (
     <div className="container mx-auto p-4">
+      <Navbar />
       <div className="shadow border bg-white rounded w-full mb-4">
         <h1 className="text-2xl font-bold p-4">Chess Tutor</h1>
       </div>

--- a/chess-tutor/src/components/Navbar.jsx
+++ b/chess-tutor/src/components/Navbar.jsx
@@ -7,7 +7,7 @@ const Navbar = () => {
         <li>
           <a href="#analysis" className="text-white hover:text-gray-400">Analysis</a>
         </li>
-        <li>
+        <li className="hidden">
           <a href="#puzzles" className="text-white hover:text-gray-400">Puzzles</a>
         </li>
       </ul>

--- a/chess-tutor/src/components/Navbar.jsx
+++ b/chess-tutor/src/components/Navbar.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const Navbar = () => {
+  return (
+    <nav className="bg-gray-800 p-4">
+      <ul className="flex space-x-4">
+        <li>
+          <a href="#analysis" className="text-white hover:text-gray-400">Analysis</a>
+        </li>
+        <li>
+          <a href="#puzzles" className="text-white hover:text-gray-400">Puzzles</a>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default Navbar;


### PR DESCRIPTION
Related to #206

Add a navbar navigation menu above the header with links to Analysis and a placeholder for Puzzles.

* Add a new `Navbar` component in `chess-tutor/src/components/Navbar.jsx` with links to Analysis and Puzzles.
* Import and include the `Navbar` component above the header in `chess-tutor/src/App.jsx`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/chess-tutor/issues/206?shareId=77e51e56-bf0e-4aaa-8184-6a97a600c617).