### PR TITLE
Add Lichess API as primary provider for move evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Chess Tutor is an interactive web application that helps users improve their che
 - React
 - [Chessboard2](https://github.com/oakmac/chessboard2) for the chessboard UI
 - [chess.js](https://github.com/jhlywa/chess.js) for chess move validation and game state
-- [Stockfish Online API](https://stockfish.online/) for move evaluation
+- [Lichess API](https://lichess.org/api) as the primary provider for move evaluation
+- [Stockfish Online API](https://stockfish.online/) as a fallback provider for move evaluation
 - [TanStack Query](https://tanstack.com/query/latest) for efficient data fetching and caching
 - [Zustand](https://docs.pmnd.rs/zustand/getting-started/introduction) for centralized state management
 - Tailwind CSS for styling
@@ -69,6 +70,7 @@ Chess Tutor is an interactive web application that helps users improve their che
 3. The application will display the current evaluation and the best move suggestion.
 4. The move history is updated after each move, showing Unicode chess piece symbols.
 5. Invalid moves will display warning messages to guide the user.
+6. The application uses the Lichess API as the primary provider for move evaluation. If the Lichess API fails or times out, the Stockfish API is used as a fallback.
 
 ## License
 


### PR DESCRIPTION
Related to #211

Add Lichess API as the primary provider for move evaluation and use Stockfish API as a fallback.

* **chess-tutor/src/hooks/useStockfishEvaluation.js**
  - Add `fetchLichess` function to fetch evaluation data from the Lichess API.
  - Update `useQuery` function to use `fetchLichess` as the primary provider.
  - Use `fetchV2` and `fetchV1` as fallback providers if `fetchLichess` fails or times out.

* **README.md**
  - Update "Technologies Used" section to include the Lichess API as the primary provider for move evaluation.
  - Update "Usage" section to reflect the use of the Lichess API for move evaluation and mention the fallback to Stockfish API.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/chess-tutor/issues/211?shareId=9d2a1e31-5033-4df1-92dc-3f0aad0db2df).