### PR TITLE
Use chess api as a fallback Stockfish provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Chess Tutor is an interactive web application that helps users improve their che
 - Detailed move history with Unicode chess piece symbols
 - Responsive design for various screen sizes
 - Zustand for centralized state management
+- Fallback to Chess API if Stockfish evaluation takes longer than 5 seconds
 
 ## Technologies Used
 
@@ -19,6 +20,7 @@ Chess Tutor is an interactive web application that helps users improve their che
 - [Chessboard2](https://github.com/oakmac/chessboard2) for the chessboard UI
 - [chess.js](https://github.com/jhlywa/chess.js) for chess move validation and game state
 - [Stockfish Online API](https://stockfish.online/) for move evaluation
+- [Chess API](https://chess-api.com/) as a fallback provider
 - [TanStack Query](https://tanstack.com/query/latest) for efficient data fetching and caching
 - [Zustand](https://docs.pmnd.rs/zustand/getting-started/introduction) for centralized state management
 - Tailwind CSS for styling


### PR DESCRIPTION
Related to #213

Implement chess API as a fallback Stockfish provider if analysis takes longer than 5 seconds.

* **chess-tutor/src/hooks/useStockfishEvaluation.js**
  * Add a new function `fetchChessApi` to handle requests to the chess API.
  * Update the main query function to use `fetchChessApi` if both Stockfish v2 and v1 APIs fail or time out.
  * Update the `fetchWithTimeout` function to handle POST requests for the chess API.

* **README.md**
  * Update the `README.md` to include information about the chess API fallback mechanism.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/chess-tutor/issues/213?shareId=85c2dfe7-483d-4141-a2c5-f039bfd74e13).