### PR TITLE
Add option to import FEN and PGN

### DIFF
--- a/chess-tutor/package-lock.json
+++ b/chess-tutor/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "chess-tutor",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chess-tutor",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@chrisoakman/chessboard2": "^0.5.0",
-        "@tanstack/react-query": "^5.51.1",
+        "@tanstack/react-query": "^5.51.15",
         "axios": "^1.7.2",
         "chess.js": "^1.0.0-beta.8",
         "react": "^18.3.1",
@@ -21,10 +21,10 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
         "autoprefixer": "^10.4.19",
-        "eslint": "^9.6.0",
+        "eslint": "^9.8.0",
         "eslint-plugin-react-refresh": "^0.4.8",
-        "postcss": "^8.4.39",
-        "tailwindcss": "^3.4.4",
+        "postcss": "^8.4.40",
+        "tailwindcss": "^3.4.7",
         "vite": "^5.3.3"
       }
     },
@@ -1448,9 +1448,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.9.tgz",
-      "integrity": "sha512-QK49YrBAo5CLNLseZ7sZgvgTy21E6NEw22eZqc4teZfH8pxV3yXc9XXOYfUI6JNpw7mfHNkAeWtBxrTyykB6HA==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.8.tgz",
+      "integrity": "sha512-MIKAclwaDFIiYtVBLzDdm16E+Ty4GwhB6wZlCAG1R3Ur+F9Qbo6PRxpA5DK7XtDgm+WlCoAY2WxAwqhmIDHg6Q==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1854,21 +1854,6 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2609,6 +2594,24 @@
         "postcss": "^8.0.0"
       }
     },
+    "node_modules/postcss-import/node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/postcss-js": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
@@ -2822,24 +2825,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -3232,6 +3217,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tailwindcss/node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3363,9 +3366,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.5.tgz",
-      "integrity": "sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
+      "integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/chess-tutor/package.json
+++ b/chess-tutor/package.json
@@ -13,7 +13,7 @@
     "@chrisoakman/chessboard2": "^0.5.0",
     "@tanstack/react-query": "^5.51.1",
     "axios": "^1.7.2",
-    "chess.js": "^1.0.0-beta.8",
+    "chess.js": "^1.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "zustand": "^4.5.4"

--- a/chess-tutor/package.json
+++ b/chess-tutor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chess-tutor",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@chrisoakman/chessboard2": "^0.5.0",
-    "@tanstack/react-query": "^5.51.1",
+    "@tanstack/react-query": "^5.51.15",
     "axios": "^1.7.2",
-    "chess.js": "^1.0.0",
+    "chess.js": "^1.0.0-beta.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "zustand": "^4.5.4"
@@ -23,10 +23,10 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.19",
-    "eslint": "^9.6.0",
+    "eslint": "^9.8.0",
     "eslint-plugin-react-refresh": "^0.4.8",
-    "postcss": "^8.4.39",
-    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.40",
+    "tailwindcss": "^3.4.7",
     "vite": "^5.3.3"
   }
 }

--- a/chess-tutor/src/App.jsx
+++ b/chess-tutor/src/App.jsx
@@ -18,6 +18,21 @@ function App() {
       <div className="flex flex-col lg:flex-row gap-4">
         <div className="lg:w-2/3">
           <ChessBoard />
+          <div className="mt-4">
+            <input
+              type="text"
+              placeholder="Enter FEN"
+              className="border p-2 mr-2"
+            />
+            <input
+              type="text"
+              placeholder="Enter PGN"
+              className="border p-2 mr-2"
+            />
+            <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+              Import
+            </button>
+          </div>
           <button
             onClick={resetGame}
             className="mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/chess-tutor/src/App.jsx
+++ b/chess-tutor/src/App.jsx
@@ -1,6 +1,7 @@
 import ChessBoard from "./components/ChessBoard";
 import MoveHistory from "./components/MoveHistory";
 import Navbar from "./components/Navbar";
+import ImportComponent from "./components/ImportComponent";
 
 import useChessStore from "./stores/useChessStore";
 
@@ -18,21 +19,7 @@ function App() {
       <div className="flex flex-col lg:flex-row gap-4">
         <div className="lg:w-2/3">
           <ChessBoard />
-          <div className="mt-4">
-            <input
-              type="text"
-              placeholder="Enter FEN"
-              className="border p-2 mr-2"
-            />
-            <input
-              type="text"
-              placeholder="Enter PGN"
-              className="border p-2 mr-2"
-            />
-            <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-              Import
-            </button>
-          </div>
+          <ImportComponent />
           <button
             onClick={resetGame}
             className="mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"

--- a/chess-tutor/src/components/ChessBoard.jsx
+++ b/chess-tutor/src/components/ChessBoard.jsx
@@ -159,28 +159,6 @@ function ChessBoard() {
         className="shadow border bg-white rounded p-4 w-full min-w-[40rem] min-h-[35rem]"
       ></div>
       <CapturedPieces capturedPieces={capturedPieces} />
-      <div className="mt-4">
-        <input
-          type="text"
-          placeholder="Enter FEN"
-          value={fenInput}
-          onChange={(e) => setFenInput(e.target.value)}
-          className="border p-2 mr-2"
-        />
-        <input
-          type="text"
-          placeholder="Enter PGN"
-          value={pgnInput}
-          onChange={(e) => setPgnInput(e.target.value)}
-          className="border p-2 mr-2"
-        />
-        <button
-          onClick={handleImport}
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-        >
-          Import
-        </button>
-      </div>
     </>
   );
 }

--- a/chess-tutor/src/components/ChessBoard.jsx
+++ b/chess-tutor/src/components/ChessBoard.jsx
@@ -13,6 +13,8 @@ function ChessBoard() {
     white: [],
     black: [],
   });
+  const [fenInput, setFenInput] = useState("");
+  const [pgnInput, setPgnInput] = useState("");
 
   const {
     chess,
@@ -133,6 +135,16 @@ function ChessBoard() {
     return `Evaluation: ${data.evaluation.toFixed(2)}`;
   };
 
+  const handleImport = () => {
+    if (fenInput) {
+      chess.load(fenInput);
+    } else if (pgnInput) {
+      chess.load_pgn(pgnInput);
+    }
+    chessboardRef.current.position(chess.fen());
+    updateCapturedPieces();
+  };
+
   return (
     <>
       <p className="text-lg p-4 mt-2 mb-4 font-semibold shadow border bg-white rounded w-full">
@@ -147,6 +159,28 @@ function ChessBoard() {
         className="shadow border bg-white rounded p-4 w-full min-w-[40rem] min-h-[35rem]"
       ></div>
       <CapturedPieces capturedPieces={capturedPieces} />
+      <div className="mt-4">
+        <input
+          type="text"
+          placeholder="Enter FEN"
+          value={fenInput}
+          onChange={(e) => setFenInput(e.target.value)}
+          className="border p-2 mr-2"
+        />
+        <input
+          type="text"
+          placeholder="Enter PGN"
+          value={pgnInput}
+          onChange={(e) => setPgnInput(e.target.value)}
+          className="border p-2 mr-2"
+        />
+        <button
+          onClick={handleImport}
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        >
+          Import
+        </button>
+      </div>
     </>
   );
 }

--- a/chess-tutor/src/components/ChessBoard.jsx
+++ b/chess-tutor/src/components/ChessBoard.jsx
@@ -13,8 +13,6 @@ function ChessBoard() {
     white: [],
     black: [],
   });
-  const [fenInput, setFenInput] = useState("");
-  const [pgnInput, setPgnInput] = useState("");
 
   const {
     chess,
@@ -133,16 +131,6 @@ function ChessBoard() {
     if (!data) return "";
     if (data.mate !== null) return `Mate in ${data.mate}`;
     return `Evaluation: ${data.evaluation.toFixed(2)}`;
-  };
-
-  const handleImport = () => {
-    if (fenInput) {
-      chess.load(fenInput);
-    } else if (pgnInput) {
-      chess.load_pgn(pgnInput);
-    }
-    chessboardRef.current.position(chess.fen());
-    updateCapturedPieces();
   };
 
   return (

--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -38,11 +38,7 @@ const ImportComponent = () => {
         />
         <button
           onClick={handleImport}
-<<<<<<< HEAD
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed" 
-=======
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
->>>>>>> b6a3767dc3cf54a91201106bfe3c9a941f0c6694
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed"
           disabled={!fenInput && !pgnInput}
         >
           Import

--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -17,7 +17,7 @@ const ImportComponent = () => {
   };
 
   return (
-    <div className="import-component">
+    <div className="mt-6">
       <div className="flex flex-col mb-4">
         <input
           type="text"

--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -38,7 +38,7 @@ const ImportComponent = () => {
         />
         <button
           onClick={handleImport}
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
           disabled={!fenInput && !pgnInput}
         >
           Import

--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -14,6 +14,9 @@ const ImportComponent = () => {
       chess.load_pgn(pgnInput);
       setPgn(pgnInput);
     }
+    chessboardRef.current.position(chess.fen());
+    setFenInput("");
+    setPgnInput("");
   };
 
   return (
@@ -35,7 +38,11 @@ const ImportComponent = () => {
         />
         <button
           onClick={handleImport}
+<<<<<<< HEAD
           className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed" 
+=======
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+>>>>>>> b6a3767dc3cf54a91201106bfe3c9a941f0c6694
           disabled={!fenInput && !pgnInput}
         >
           Import

--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react";
+import useChessStore from "../stores/useChessStore";
+
+const ImportComponent = () => {
+  const [fenInput, setFenInput] = useState("");
+  const [pgnInput, setPgnInput] = useState("");
+  const { chess, setFen, setPgn } = useChessStore();
+
+  const handleImport = () => {
+    if (fenInput) {
+      chess.load(fenInput);
+      setFen(fenInput);
+    } else if (pgnInput) {
+      chess.load_pgn(pgnInput);
+      setPgn(pgnInput);
+    }
+  };
+
+  return (
+    <div className="import-component">
+      <div className="flex flex-col mb-4">
+        <input
+          type="text"
+          value={fenInput}
+          onChange={(e) => setFenInput(e.target.value)}
+          placeholder="Enter FEN"
+          className="mb-2 p-2 border rounded"
+        />
+        <input
+          type="text"
+          value={pgnInput}
+          onChange={(e) => setPgnInput(e.target.value)}
+          placeholder="Enter PGN"
+          className="mb-2 p-2 border rounded"
+        />
+        <button
+          onClick={handleImport}
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        >
+          Import
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ImportComponent;

--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -35,8 +35,8 @@ const ImportComponent = () => {
         />
         <button
           onClick={handleImport}
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-          disabled={!fenInput || !pgnInput}
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-50 disabled:cursor-not-allowed" 
+          disabled={!fenInput && !pgnInput}
         >
           Import
         </button>

--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -36,6 +36,7 @@ const ImportComponent = () => {
         <button
           onClick={handleImport}
           className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          disabled={!fenInput || !pgnInput}
         >
           Import
         </button>

--- a/chess-tutor/src/stores/useChessStore.js
+++ b/chess-tutor/src/stores/useChessStore.js
@@ -8,6 +8,8 @@ const useChessStore = create((set, get) => ({
   evaluationData: null,
   isLoading: false,
   error: null,
+  fen: "",
+  pgn: "",
 
   makeMove: (from, to) => {
     const { chess } = get();
@@ -37,6 +39,9 @@ const useChessStore = create((set, get) => ({
   setIsLoading: (isLoading) => set({ isLoading }),
   setError: (error) => set({ error }),
 
+  setFen: (fen) => set({ fen }),
+  setPgn: (pgn) => set({ pgn }),
+
   resetGame: () => {
     set({
       chess: new Chess(),
@@ -45,6 +50,8 @@ const useChessStore = create((set, get) => ({
       evaluationData: null,
       isLoading: false,
       error: null,
+      fen: "",
+      pgn: "",
     });
   },
 }));


### PR DESCRIPTION
Related to #216

Add input fields for importing FEN and PGN to the chessboard component.

* **ChessBoard.jsx**
  - Add state variables `fenInput` and `pgnInput` to store the input values.
  - Add input fields for FEN and PGN below the chessboard.
  - Implement `handleImport` function to load the FEN or PGN into the chessboard and update the position.
  - Update the chessboard position and captured pieces after importing FEN or PGN.

* **App.jsx**
  - Add input fields for FEN and PGN below the chessboard.
  - Add an import button to trigger the import action.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/chess-tutor/issues/216?shareId=310aaaf8-f5f6-443d-a7c2-66c8fe144540).