### PR TITLE
Fix move history update after importing game

### DIFF
--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -5,17 +5,18 @@ import { chessboardRef } from "./ChessBoard";
 const ImportComponent = () => {
   const [fenInput, setFenInput] = useState("");
   const [pgnInput, setPgnInput] = useState("");
-  const { chess, setFen, setPgn } = useChessStore();
+  const { chess, setFen, setPgn, updateMoveHistory } = useChessStore();
 
   const handleImport = () => {
     if (fenInput) {
       chess.load(fenInput);
       setFen(fenInput);
     } else if (pgnInput) {
-      chess.loadPgn(pgnInput); // P687c
+      chess.loadPgn(pgnInput);
       setPgn(pgnInput);
     }
     chessboardRef.current.position(chess.fen());
+    updateMoveHistory();
     setFenInput("");
     setPgnInput("");
   };

--- a/chess-tutor/src/stores/useChessStore.js
+++ b/chess-tutor/src/stores/useChessStore.js
@@ -49,6 +49,13 @@ const useChessStore = create((set, get) => ({
     updateMoveHistory();
   },
 
+  loadFen: (fen) => {
+    const { chess, updateMoveHistory } = get();
+    chess.load(fen);
+    set({ fen });
+    updateMoveHistory();
+  },
+
   updateMoveHistory: () => {
     const { chess } = get();
     set({ moveHistory: chess.history({ verbose: true }) });

--- a/chess-tutor/src/stores/useChessStore.js
+++ b/chess-tutor/src/stores/useChessStore.js
@@ -43,9 +43,15 @@ const useChessStore = create((set, get) => ({
   setPgn: (pgn) => set({ pgn }),
 
   loadPgn: (pgn) => {
-    const { chess } = get();
+    const { chess, updateMoveHistory } = get();
     chess.load_pgn(pgn);
     set({ pgn });
+    updateMoveHistory();
+  },
+
+  updateMoveHistory: () => {
+    const { chess } = get();
+    set({ moveHistory: chess.history({ verbose: true }) });
   },
 
   resetGame: () => {


### PR DESCRIPTION
Related to #223

Update move history after importing a game with FEN or PGN.

* **ImportComponent.jsx**
  - Import `updateMoveHistory` from `useChessStore`.
  - Call `updateMoveHistory` after setting FEN or PGN in `handleImport`.

* **useChessStore.js**
  - Add `updateMoveHistory` function to update the move history state.
  - Call `updateMoveHistory` in `loadPgn` after loading the PGN.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/chess-tutor/issues/223?shareId=c6a88aae-fe82-4225-b6a8-332a1645b925).