### PR TITLE
Fix move history update after import

### DIFF
--- a/chess-tutor/src/components/ImportComponent.jsx
+++ b/chess-tutor/src/components/ImportComponent.jsx
@@ -40,7 +40,7 @@ const ImportComponent = () => {
         />
         <button
           onClick={handleImport}
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded disabled:opacity-30 disabled:cursor-not-allowed" 
           disabled={!fenInput && !pgnInput}
         >
           Import

--- a/chess-tutor/src/stores/useChessStore.js
+++ b/chess-tutor/src/stores/useChessStore.js
@@ -58,7 +58,7 @@ const useChessStore = create((set, get) => ({
 
   updateMoveHistory: () => {
     const { chess } = get();
-    set({ moveHistory: chess.history({ verbose: true }) });
+    set({ moveHistory: [...chess.history({ verbose: true })] });
   },
 
   resetGame: () => {


### PR DESCRIPTION
Related to #225

Update the `<MoveHistory />` component to show moves after importing a FEN or PGN game.

* Modify `updateMoveHistory` function in `chess-tutor/src/stores/useChessStore.js` to trigger a re-render of the `<MoveHistory />` component by updating the `moveHistory` state with a new array.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/chess-tutor/issues/225?shareId=f8be9695-17b0-4628-af02-c380749164ee).